### PR TITLE
Add compatibility with appium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,7 @@ test-results/
 # uv
 .python-version
 uv.lock
+
+# AI
 GEMINI.md
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ test-results/
 # uv
 .python-version
 uv.lock
+GEMINI.md

--- a/README.md
+++ b/README.md
@@ -208,12 +208,13 @@ if __name__ == "__main__":
 3. Type: `await typer.type(element, "your text")`
 
 
-### Selenium (Sync)
+### Selenium & Appium (Sync)
 
 ```python
 from selenium import webdriver
-from src.integration import HumanTyper
+from humantyping import HumanTyper
 
+# For Selenium
 driver = webdriver.Chrome()
 driver.get("https://example.com")
 
@@ -222,6 +223,12 @@ search_box = driver.find_element("name", "search")
 human.type_sync(search_box, "Typing with human-like behavior")
 
 driver.quit()
+
+# For Appium
+# from appium import webdriver
+# ... driver setup ...
+# search_field = driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='Search')
+# human.type_sync(search_field, "Typing on mobile")
 ```
 
 **The integration module handles all typing events:**

--- a/examples/appium_example.py
+++ b/examples/appium_example.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import time
+from appium import webdriver
+from appium.options.android import UiAutomator2Options
+from appium.webdriver.common.appiumby import AppiumBy
+
+# Add parent directory to path to import humantyping
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from humantyping.integration import HumanTyper
+
+
+def main():
+    """
+    Example of using HumanTyping with Appium for native Android automation.
+    This example automates the native Google Search app (QuickSearchBox).
+    It avoids using Chromedriver by interacting with the native UI.
+    """
+    # Load Device UUID (UDID) from environment variable
+    device_uuid = os.environ.get("APPIUM_DEVICE_UUID")
+
+    if not device_uuid:
+        print("⚠️ Warning: APPIUM_DEVICE_UUID environment variable not set.")
+        print("Please set it: export APPIUM_DEVICE_UUID='your_device_udid'")
+
+    print(f"Setting up Appium capabilities for Device: {device_uuid or 'Default'}")
+
+    options = UiAutomator2Options()
+    options.platform_name = "Android"
+    options.automation_name = "UiAutomator2"
+    if device_uuid:
+        options.udid = device_uuid
+
+    # Automate the native Google App instead of Chrome browser
+    options.app_package = "com.google.android.googlequicksearchbox"
+    options.app_activity = "com.google.android.googlequicksearchbox.SearchActivity"
+    options.no_reset = True
+
+    print("Connecting to Appium server...")
+    try:
+        # Default Appium server URL is http://localhost:4723
+        driver = webdriver.Remote("http://localhost:4723", options=options)
+    except Exception as e:
+        print(f"❌ Failed to connect to Appium server: {e}")
+        return
+
+    try:
+        # Create HumanTyper
+        human = HumanTyper(wpm=45)
+
+        print("Waiting for Google Search to load...")
+        time.sleep(2)
+
+        # Finding the search box in the native Google App
+        # Note: Resource IDs can vary slightly by Android version
+        print("Finding native search field...")
+        try:
+            # Common ID for the search input in Google App
+            search_button = driver.find_element(
+                by=AppiumBy.XPATH,
+                value='(//android.widget.FrameLayout[@resource-id="com.google.android.googlequicksearchbox:id/navigation_bar_item_icon_container"])[2]',
+            )
+            search_button.click()
+
+            search_box = driver.find_element(
+                by=AppiumBy.XPATH,
+                value='//android.widget.EditText[@resource-id="com.google.android.googlequicksearchbox:id/googleapp_search_box"]',
+            )
+        except:
+            # Fallback to a more generic search for an editable field
+            print("ID search failed, looking for any focused edit text...")
+            search_box = driver.switch_to.active_element
+
+        print("Clicking search box...")
+        search_box.click()
+
+        # Type realistically using the synchronous integration
+        print("Typing like a human on native Android app...")
+        human.type_sync(search_box, "Human typing on native Android")
+
+        print("✅ Finished typing.")
+        time.sleep(2)
+
+    except Exception as e:
+        print(f"❌ Error during automation: {e}")
+    finally:
+        print("Closing session...")
+        driver.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/appium_example.py
+++ b/examples/appium_example.py
@@ -75,9 +75,9 @@ def main():
         print("Clicking search box...")
         search_box.click()
 
-        # Type realistically using the synchronous integration
+        # Type realistically using the specialized Appium integration
         print("Typing like a human on native Android app...")
-        human.type_sync(search_box, "Human typing on native Android")
+        human.type_appium(driver, "Human typing on native Android")
 
         print("✅ Finished typing.")
         time.sleep(2)

--- a/examples/appium_example.py
+++ b/examples/appium_example.py
@@ -47,7 +47,7 @@ def main():
 
     try:
         # Create HumanTyper
-        human = HumanTyper(wpm=45)
+        human = HumanTyper(wpm=150)
 
         print("Waiting for Google Search to load...")
         time.sleep(2)

--- a/humantyping/integration.py
+++ b/humantyping/integration.py
@@ -2,10 +2,12 @@ import time
 import asyncio
 from .typer import MarkovTyper
 
+
 class HumanTyper:
     """
-    A helper class to integrate realistic typing into automation frameworks like Playwright or Selenium.
+    A helper class to integrate realistic typing into automation frameworks like Playwright, Selenium, or Appium.
     """
+
     def __init__(self, wpm=60.0, layout="qwerty"):
         self.wpm = wpm
         self.layout = layout
@@ -13,17 +15,17 @@ class HumanTyper:
     async def type(self, page_element, text):
         """
         Types text into a Playwright element with realistic human behavior.
-        
+
         This is the main method for Playwright integration. It simulates:
         - Variable typing speed based on word complexity
         - Realistic errors (neighbor keys, swaps)
         - Natural corrections with backspace or arrow keys
         - Fatigue over longer texts
-        
+
         Args:
             page_element: The Playwright Locator or ElementHandle to type into.
             text: The text to type with human-like behavior.
-            
+
         Example:
             typer = HumanTyper(wpm=70)
             input_box = page.locator("input[name='search']")
@@ -33,7 +35,7 @@ class HumanTyper:
         # 1. Generate the realistic keystroke sequence
         typer = MarkovTyper(text, target_wpm=self.wpm, layout=self.layout)
         _, history = typer.run()
-        
+
         last_time = 0.0
         current_text_on_screen = ""
 
@@ -66,13 +68,21 @@ class HumanTyper:
             elif "ARROW_RIGHT" in action:
                 await page_element.press("ArrowRight")
 
-    def type_sync(self, selenium_element, text):
+    def type_appium(self, driver, text):
         """
-        Types text into a Selenium WebElement (or any sync object with send_keys).
-        Note: Selenium send_keys usually appends, so handling backspace might need specific keys.
-        """
-        from selenium.webdriver.common.keys import Keys
+        Types text into the focused Android element using Appium's mobile: type extension.
+        This operates at the driver level and requires the element to be focused.
         
+        Args:
+            driver: The Appium WebDriver.
+            text: The text to type.
+            
+        Example:
+            typer = HumanTyper(wpm=45)
+            search_box = driver.find_element(...)
+            search_box.click() # Ensure focus
+            typer.type_appium(driver, "Hello Appium")
+        """
         typer = MarkovTyper(text, target_wpm=self.wpm, layout=self.layout)
         _, history = typer.run()
         
@@ -85,11 +95,39 @@ class HumanTyper:
             last_time = t
 
             if "BACKSPACE" in action:
+                driver.keyevent(67)  # KEYCODE_DEL
+            elif "ARROW_LEFT" in action:
+                driver.keyevent(21)  # KEYCODE_DPAD_LEFT
+            elif "ARROW_RIGHT" in action:
+                driver.keyevent(22)  # KEYCODE_DPAD_RIGHT
+            elif "TYPED" in action:  # Handles TYPED, TYPED_ERROR, TYPED_SWAP
+                char = action.split("'")[1]
+                driver.execute_script('mobile: type', {'text': char})
+
+    def type_sync(self, selenium_element, text):
+        """
+        Types text into a Selenium WebElement (or any sync object with send_keys).
+        Note: Selenium send_keys usually appends, so handling backspace might need specific keys.
+        """
+        from selenium.webdriver.common.keys import Keys
+
+        typer = MarkovTyper(text, target_wpm=self.wpm, layout=self.layout)
+        _, history = typer.run()
+
+        last_time = 0.0
+
+        for t, action, _ in history:
+            delay = t - last_time
+            if delay > 0:
+                time.sleep(delay)
+            last_time = t
+
+            if "BACKSPACE" in action:
                 selenium_element.send_keys(Keys.BACK_SPACE)
             elif "ARROW_LEFT" in action:
                 selenium_element.send_keys(Keys.ARROW_LEFT)
             elif "ARROW_RIGHT" in action:
                 selenium_element.send_keys(Keys.ARROW_RIGHT)
-            elif "TYPED" in action: # Handles TYPED, TYPED_ERROR, TYPED_SWAP
+            elif "TYPED" in action:  # Handles TYPED, TYPED_ERROR, TYPED_SWAP
                 char = action.split("'")[1]
                 selenium_element.send_keys(char)

--- a/humantyping/integration.py
+++ b/humantyping/integration.py
@@ -2,12 +2,10 @@ import time
 import asyncio
 from .typer import MarkovTyper
 
-
 class HumanTyper:
     """
-    A helper class to integrate realistic typing into automation frameworks like Playwright, Selenium, or Appium.
+    A helper class to integrate realistic typing into automation frameworks like Playwright or Selenium.
     """
-
     def __init__(self, wpm=60.0, layout="qwerty"):
         self.wpm = wpm
         self.layout = layout
@@ -15,17 +13,17 @@ class HumanTyper:
     async def type(self, page_element, text):
         """
         Types text into a Playwright element with realistic human behavior.
-
+        
         This is the main method for Playwright integration. It simulates:
         - Variable typing speed based on word complexity
         - Realistic errors (neighbor keys, swaps)
         - Natural corrections with backspace or arrow keys
         - Fatigue over longer texts
-
+        
         Args:
             page_element: The Playwright Locator or ElementHandle to type into.
             text: The text to type with human-like behavior.
-
+            
         Example:
             typer = HumanTyper(wpm=70)
             input_box = page.locator("input[name='search']")
@@ -35,7 +33,7 @@ class HumanTyper:
         # 1. Generate the realistic keystroke sequence
         typer = MarkovTyper(text, target_wpm=self.wpm, layout=self.layout)
         _, history = typer.run()
-
+        
         last_time = 0.0
         current_text_on_screen = ""
 
@@ -68,25 +66,18 @@ class HumanTyper:
             elif "ARROW_RIGHT" in action:
                 await page_element.press("ArrowRight")
 
-    def type_sync(self, element, text):
+    def type_sync(self, selenium_element, text):
         """
-        Types text into a Selenium or Appium WebElement (or any sync object with send_keys).
-
-        Args:
-            element: The WebElement (Selenium/Appium) to type into.
-            text: The text to type.
-
-        Note:
-            send_keys usually appends, so handling backspace might need specific keys.
-            This method is compatible with both Selenium and Appium.
+        Types text into a Selenium WebElement (or any sync object with send_keys).
+        Note: Selenium send_keys usually appends, so handling backspace might need specific keys.
         """
-        # from selenium.webdriver.common.keys import Keys
-
+        from selenium.webdriver.common.keys import Keys
+        
         typer = MarkovTyper(text, target_wpm=self.wpm, layout=self.layout)
         _, history = typer.run()
-
+        
         last_time = 0.0
-
+        
         for t, action, _ in history:
             delay = t - last_time
             if delay > 0:
@@ -94,9 +85,11 @@ class HumanTyper:
             last_time = t
 
             if "BACKSPACE" in action:
-                element.send_keys(Keys.BACK_SPACE)
+                selenium_element.send_keys(Keys.BACK_SPACE)
+            elif "ARROW_LEFT" in action:
+                selenium_element.send_keys(Keys.ARROW_LEFT)
             elif "ARROW_RIGHT" in action:
-                element.send_keys(Keys.ARROW_RIGHT)
-            elif "TYPED" in action:  # Handles TYPED, TYPED_ERROR, TYPED_SWAP
+                selenium_element.send_keys(Keys.ARROW_RIGHT)
+            elif "TYPED" in action: # Handles TYPED, TYPED_ERROR, TYPED_SWAP
                 char = action.split("'")[1]
-                element.send_keys(char)
+                selenium_element.send_keys(char)

--- a/humantyping/integration.py
+++ b/humantyping/integration.py
@@ -2,10 +2,12 @@ import time
 import asyncio
 from .typer import MarkovTyper
 
+
 class HumanTyper:
     """
-    A helper class to integrate realistic typing into automation frameworks like Playwright or Selenium.
+    A helper class to integrate realistic typing into automation frameworks like Playwright, Selenium, or Appium.
     """
+
     def __init__(self, wpm=60.0, layout="qwerty"):
         self.wpm = wpm
         self.layout = layout
@@ -13,17 +15,17 @@ class HumanTyper:
     async def type(self, page_element, text):
         """
         Types text into a Playwright element with realistic human behavior.
-        
+
         This is the main method for Playwright integration. It simulates:
         - Variable typing speed based on word complexity
         - Realistic errors (neighbor keys, swaps)
         - Natural corrections with backspace or arrow keys
         - Fatigue over longer texts
-        
+
         Args:
             page_element: The Playwright Locator or ElementHandle to type into.
             text: The text to type with human-like behavior.
-            
+
         Example:
             typer = HumanTyper(wpm=70)
             input_box = page.locator("input[name='search']")
@@ -33,7 +35,7 @@ class HumanTyper:
         # 1. Generate the realistic keystroke sequence
         typer = MarkovTyper(text, target_wpm=self.wpm, layout=self.layout)
         _, history = typer.run()
-        
+
         last_time = 0.0
         current_text_on_screen = ""
 
@@ -66,18 +68,25 @@ class HumanTyper:
             elif "ARROW_RIGHT" in action:
                 await page_element.press("ArrowRight")
 
-    def type_sync(self, selenium_element, text):
+    def type_sync(self, element, text):
         """
-        Types text into a Selenium WebElement (or any sync object with send_keys).
-        Note: Selenium send_keys usually appends, so handling backspace might need specific keys.
+        Types text into a Selenium or Appium WebElement (or any sync object with send_keys).
+
+        Args:
+            element: The WebElement (Selenium/Appium) to type into.
+            text: The text to type.
+
+        Note:
+            send_keys usually appends, so handling backspace might need specific keys.
+            This method is compatible with both Selenium and Appium.
         """
-        from selenium.webdriver.common.keys import Keys
-        
+        # from selenium.webdriver.common.keys import Keys
+
         typer = MarkovTyper(text, target_wpm=self.wpm, layout=self.layout)
         _, history = typer.run()
-        
+
         last_time = 0.0
-        
+
         for t, action, _ in history:
             delay = t - last_time
             if delay > 0:
@@ -85,11 +94,9 @@ class HumanTyper:
             last_time = t
 
             if "BACKSPACE" in action:
-                selenium_element.send_keys(Keys.BACK_SPACE)
-            elif "ARROW_LEFT" in action:
-                selenium_element.send_keys(Keys.ARROW_LEFT)
+                element.send_keys(Keys.BACK_SPACE)
             elif "ARROW_RIGHT" in action:
-                selenium_element.send_keys(Keys.ARROW_RIGHT)
-            elif "TYPED" in action: # Handles TYPED, TYPED_ERROR, TYPED_SWAP
+                element.send_keys(Keys.ARROW_RIGHT)
+            elif "TYPED" in action:  # Handles TYPED, TYPED_ERROR, TYPED_SWAP
                 char = action.split("'")[1]
-                selenium_element.send_keys(char)
+                element.send_keys(char)

--- a/humantyping/integration.py
+++ b/humantyping/integration.py
@@ -70,7 +70,7 @@ class HumanTyper:
 
     def type_appium(self, driver, text):
         """
-        Types text into the focused Android element using Appium's mobile: type extension.
+        Types text into the focused mobile element using W3C Actions.
         This operates at the driver level and requires the element to be focused.
         
         Args:
@@ -83,6 +83,9 @@ class HumanTyper:
             search_box.click() # Ensure focus
             typer.type_appium(driver, "Hello Appium")
         """
+        from selenium.webdriver.common.action_chains import ActionChains
+        from selenium.webdriver.common.keys import Keys
+
         typer = MarkovTyper(text, target_wpm=self.wpm, layout=self.layout)
         _, history = typer.run()
         
@@ -94,15 +97,18 @@ class HumanTyper:
                 time.sleep(delay)
             last_time = t
 
+            actions = ActionChains(driver)
             if "BACKSPACE" in action:
-                driver.keyevent(67)  # KEYCODE_DEL
+                actions.send_keys(Keys.BACK_SPACE)
             elif "ARROW_LEFT" in action:
-                driver.keyevent(21)  # KEYCODE_DPAD_LEFT
+                actions.send_keys(Keys.ARROW_LEFT)
             elif "ARROW_RIGHT" in action:
-                driver.keyevent(22)  # KEYCODE_DPAD_RIGHT
+                actions.send_keys(Keys.ARROW_RIGHT)
             elif "TYPED" in action:  # Handles TYPED, TYPED_ERROR, TYPED_SWAP
                 char = action.split("'")[1]
-                driver.execute_script('mobile: type', {'text': char})
+                actions.send_keys(char)
+            
+            actions.perform()
 
     def type_sync(self, selenium_element, text):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,15 +35,19 @@ classifiers = [
 ]
 
 dependencies = [
+    "appium-python-client>=5.2.6",
     "numpy>=1.24.0",
+    "selenium>=4.41.0",
 ]
 
 [project.optional-dependencies]
 playwright = ["playwright>=1.40.0"]
 selenium = ["selenium>=4.0.0"]
+appium = ["Appium-Python-Client>=3.0.0"]
 dev = [
     "playwright>=1.40.0",
     "selenium>=4.0.0",
+    "Appium-Python-Client>=3.0.0",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
 ]


### PR DESCRIPTION
The python appium client is always the same for IOS, Android, the browser, and desktop apps. So, you can use now the library in any platform that is automate with appium. But, this implementation was only tested on an Android device.

Create a new method on the HumanTyper class, called type_appium.